### PR TITLE
Fixed typo

### DIFF
--- a/Keyed/Incidents.xml
+++ b/Keyed/Incidents.xml
@@ -31,7 +31,7 @@
   <!-- EN: Transport pod crash -->
   <LetterLabelRefugeePodCrash>Rettungskapsel</LetterLabelRefugeePodCrash>
   <!-- EN: {PAWN_titleIndef} named {PAWN_nameDef} is crashing in a transport pod nearby. If {PAWN_pronoun} survives the impact, {PAWN_pronoun} will be badly wounded. -->
-  <RefugeePodCrash>{PAWN_titleIndef} namens {PAWN_nameDef} ist mit einer Rettungskapel in der Nähe abgestürzt. Wenn {PAWN_pronoun} den Aufschlag überlebt hat, ist {PAWN_pronoun} vermutlich schwer verletzt.</RefugeePodCrash>
+  <RefugeePodCrash>{PAWN_titleIndef} namens {PAWN_nameDef} ist mit einer Rettungskapsel in der Nähe abgestürzt. Wenn {PAWN_pronoun} den Aufschlag überlebt hat, ist {PAWN_pronoun} vermutlich schwer verletzt.</RefugeePodCrash>
   <!-- EN: {PAWN_nameDef} is not affiliated with any faction. You can rescue {PAWN_objective} and hope {PAWN_pronoun} joins freely, or capture {PAWN_objective} for recruitment or slavery purposes. -->
   <RefugeePodCrash_Factionless>{PAWN_nameDef} gehört zu keiner Fraktion. Du kannst {PAWN_objective} retten und hoffen, dass {PAWN_pronoun} freiwillig bleibt, oder fange {PAWN_objective} zum Rekrutieren oder Versklaven ein.</RefugeePodCrash_Factionless>
   <!-- EN: {PAWN_nameDef} is from your enemy {PAWN_factionName}. You can capture {PAWN_objective} for recruitment or slavery purposes. -->


### PR DESCRIPTION
Beim Rettungskapsel-Event heißt es im Text "Rettungskapel" und nicht "Rettungskapsel".