### PR TITLE
Update Factions_Player.xml

### DIFF
--- a/Core/DefInjected/FactionDef/Factions_Player.xml
+++ b/Core/DefInjected/FactionDef/Factions_Player.xml
@@ -15,8 +15,8 @@
   <!-- EN: A small tribe. -->
   <PlayerTribe.description>Ein kleiner Stamm.</PlayerTribe.description>
   <!-- EN: tribesman -->
-  <PlayerTribe.pawnSingular>Ureinwohner</PlayerTribe.pawnSingular>
+  <PlayerTribe.pawnSingular>Stammesmitglied</PlayerTribe.pawnSingular>
   <!-- EN: tribespeople -->
-  <PlayerTribe.pawnsPlural>Ureinwohner</PlayerTribe.pawnsPlural>
+  <PlayerTribe.pawnsPlural>Stammesmitglieder</PlayerTribe.pawnsPlural>
   
 </LanguageData>


### PR DESCRIPTION
Zeile 18, 20.
"Ureinwohner" -> "Stammesmitglied" und "Stammesmitglieder"
Wenn "Stamm" , so wie in z.14, dann "Stammesmitglied"/Stammesmitglieder" für mehr Einheitlichkeit und Universelleren Gebrauch.

Ob es sinnvoll ist, kann man gerne besprechen.