### PR TITLE
More cases for Scripts_Utility_ThreatsCore

### DIFF
--- a/Core/DefInjected/QuestScriptDef/Scripts_Utility_ThreatsCore.xml
+++ b/Core/DefInjected/QuestScriptDef/Scripts_Utility_ThreatsCore.xml
@@ -13,8 +13,10 @@
       <li>root(priority=1,sitePart==EMIDynamo)->(*Threat)ein EMI-Generator(/Threat) ist, der in der ganzen Region elektrische Geräte ausfallen lassen kann</li>
       <li>root(priority=1,sitePart==ToxicSpewer)->(*Threat)ein Giftgenerator(/Threat) ist, der die ganze Region mit Gift besprüht</li>
       <li>root(priority=1,sitePart==RaidSource)->ein militärischer Sammelpunkt ist, der von (*Threat)[enemiesCount] Gegnern ([enemiesLabel])(/Threat) bewacht wird, die deine Kolonie alle [mtbDays] überfallen werden</li>
-      <li>root(priority=1,sitePart==Outpost)->ein gegnerischer Außenposten ist, der von (*Threat)[enemiesCount] Gegnern ([enemiesLabel])(/Threat) bewacht wird</li>
-      <li>root(priority=1,sitePart==BanditCamp)->ein Banditenlager ist, das von (*Threat)[enemiesCount] Gegnern ([enemiesLabel])(/Threat) bewacht wird</li>
+      <li>root(priority=1,sitePart==Outpost,enemiesCount==1)->ein gegnerischer Außenposten ist, der von (*Threat)[enemiesCount] Gegner ([enemiesLabel])(/Threat) bewacht wird</li>
+	  <li>root(priority=1,sitePart==Outpost,enemiesCount>1)->ein gegnerischer Außenposten ist, der von (*Threat)[enemiesCount] Gegnern ([enemiesLabel])(/Threat) bewacht wird</li>
+      <li>root(priority=1,sitePart==BanditCamp,enemiesCount==1)->ein Banditenlager ist, das von (*Threat)[enemiesCount] Gegner ([enemiesLabel])(/Threat) bewacht wird</li>
+	  <li>root(priority=1,sitePart==BanditCamp,enemiesCount>1)->ein Banditenlager ist, das von (*Threat)[enemiesCount] Gegnern ([enemiesLabel])(/Threat) bewacht wird</li>
       <li>root(priority=1,sitePart==Manhunters,count==1)->(*Threat)[count] [kindLabel](/Threat) jeden Menschen in Sichtweite angreifen wird</li>
       <li>root(priority=1,sitePart==Manhunters,count>1)->(*Threat)[count] menschenjagende [kindLabel](/Threat) gesichtet wurden</li>
       <li>root(priority=1,sitePart==SleepingMechanoids,count==1)->(*Threat)ein schlafender Mechanoid(/Threat) in der Nähe ist</li>


### PR DESCRIPTION
Ich hatte einmal eine Quest, in der ein gegnerischer Außenposten mit nur einem Gegner besetzt war. Für diesen Fall gab es jedoch keine Extra-Kondition und es wurde "1 Gegnern" geschrieben.

So etwas wurde nun für "Outpost" und "BanditCamp" hinzugefügt.  Da diese Fälle sehr selten sind, konnte ich sie bisher jedoch nicht noch mal zu Testzwecken nachstellen.