### PR TITLE
PlantNeedsLightLevel -> benötigte Lichtstärke

### DIFF
--- a/Core/Keyed/Misc_Gameplay.xml
+++ b/Core/Keyed/Misc_Gameplay.xml
@@ -1163,7 +1163,7 @@
   <!-- EN: Fully grown in {0} of growth. -->
   <FullyGrownIn>Ist in {replace: {0}; "Tage"-"Tagen"; "Jahre"-"Jahren"} ausgewachsen.</FullyGrownIn>
   <!-- EN: needs light level -->
-  <PlantNeedsLightLevel>Lichtstärke nur</PlantNeedsLightLevel>
+  <PlantNeedsLightLevel>benötigte Lichtstärke</PlantNeedsLightLevel>
   <!-- EN: resting -->
   <PlantResting>ruht</PlantResting>
   <!-- EN: temperature growth multiplier {0}% -->


### PR DESCRIPTION
Bisher steht im Tooltip zum Wachstum von Pflanzen
> Wachstumsrate: 0% (ruht, Lichtstärke nur 51%)

mit der Änderung sollte das dann wie folgt aussehen:
> Wachstumsrate: 0% (ruht, benötigte Lichtstärke 51%)

Ich denke das trifft es besser.